### PR TITLE
Update utils.js ajout d'un code naf pour les caisses des école

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -49,6 +49,7 @@ const validNAFCode = {
     '84', // SERVICES D’ADMINISTRATION PUBLIQUE ET DE DÉFENSE ; SERVICES DE SÉCURITÉ SOCIALE OBLIGATOIRE
     '85', // ENSEIGNEMENT
     '86', // ACTIVITÉS POUR LA SANTÉ HUMAINE
+    '88', // Action sociale sans hébergement
   ],
 };
 


### PR DESCRIPTION
Lors de la saisie du siret la caisse des écoles a un message d'alerte car soin code naf n'est pas dans notre liste. 
J'ai vérifier pour d'autres caisses des écoles qu'elle disposaient bien d'un code naf identique
Du coup j'ai ajouter le code 88 à la liste