### PR TITLE
Replace html character reference

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -332,8 +332,8 @@ class Form extends React.Component {
           <div className="form__group">
             <label htmlFor="description">
               Décrivez brièvement la raison pour laquelle vous collectez des
-              données à caractère personnel, c'est-à-dire l&apos;objectif qui
-              est poursuivi par le traitement que vous mettez en place.
+              données à caractère personnel, c'est-à-dire l’objectif qui est
+              poursuivi par le traitement que vous mettez en place.
             </label>
             <textarea
               rows="10"
@@ -547,7 +547,7 @@ class Form extends React.Component {
         </ScrollablePanel>
 
         <ScrollablePanel scrollableId="cgu">
-          <h2>Modalités d&apos;utilisation</h2>
+          <h2>Modalités d’utilisation</h2>
           <CguDescription />
           <div className="form__group">
             <input
@@ -561,7 +561,7 @@ class Form extends React.Component {
             <label htmlFor="cgu_approved" className="label-inline">
               J'ai pris connaissance des{' '}
               <a href={cguLink} target="_blank" rel="noreferrer noopener">
-                modalités d&apos;utilisation
+                modalités d’utilisation
               </a>{' '}
               et je les valide. Je confirme que le DPD de mon organisation est
               informé de ma demande.

--- a/src/components/form/DgfipEntrantsTechniques.js
+++ b/src/components/form/DgfipEntrantsTechniques.js
@@ -56,7 +56,7 @@ const DgfipEntrantsTechniques = ({
         </div>
         <div className="form__group">
           <label htmlFor="autorite_homologation_nom">
-            Nom de l&apos;autorité d&apos;homologation
+            Nom de l’autorité d’homologation
           </label>
           <input
             type="text"
@@ -69,7 +69,7 @@ const DgfipEntrantsTechniques = ({
         </div>
         <div className="form__group">
           <label htmlFor="autorite_homologation_fonction">
-            Fonction de l&apos;autorité d&apos;homologation
+            Fonction de l’autorité d’homologation
           </label>
           <input
             type="text"
@@ -82,7 +82,7 @@ const DgfipEntrantsTechniques = ({
         </div>
         <div className="form__group">
           <label htmlFor="date_homologation">
-            Date de début l&apos;homologation
+            Date de début l’homologation
           </label>
           <input
             type="date"
@@ -95,7 +95,7 @@ const DgfipEntrantsTechniques = ({
         </div>
         <div className="form__group">
           <label htmlFor="date_fin_homologation">
-            Date de fin de l&apos;homologation
+            Date de fin de l’homologation
           </label>
           <input
             type="date"
@@ -305,8 +305,8 @@ const DgfipEntrantsTechniques = ({
             htmlFor="checkbox-recette_fonctionnelle"
             className="label-inline"
           >
-            J&apos;atteste avoir réalisé une recette fonctionnelle et qualifié
-            mon téléservice.
+            J’atteste avoir réalisé une recette fonctionnelle et qualifié mon
+            téléservice.
           </label>
         </div>
       </ScrollablePanel>

--- a/src/pages/ApiDroitsCnam.js
+++ b/src/pages/ApiDroitsCnam.js
@@ -12,13 +12,13 @@ const DemarcheDescription = () => (
   <div className="text-quote">
     <p>
       Dans le cadre du programme « Dites-le nous une fois », visant à simplifier
-      les démarches administratives des usagers, l&apos;API Droits CNAM permet
-      de récupérer des informations d'assurance maladie des usagers de façon à
-      leur éviter la transmission d'information papier.
+      les démarches administratives des usagers, l’API Droits CNAM permet de
+      récupérer des informations d'assurance maladie des usagers de façon à leur
+      éviter la transmission d'information papier.
     </p>
     <p>
       Ce portail permet de faciliter le raccordement du téléservice des
-      fournisseurs de service à l&apos;API Droits CNAM.
+      fournisseurs de service à l’API Droits CNAM.
     </p>
     <p>
       Pour faciliter votre racordement à l'API Droits CNAM, une{' '}

--- a/src/pages/FranceConnect.js
+++ b/src/pages/FranceConnect.js
@@ -11,14 +11,14 @@ const DemarcheDescription = () => (
   <div className="text-quote">
     <p>
       Pour implémenter FranceConnect sur votre site en ligne, vous devez obtenir
-      une habilitation. L&apos;accès à ce service n&apos;est pour l&apos;instant
-      disponible que si vous êtes:
+      une habilitation. L’accès à ce service n’est pour l’instant disponible que
+      si vous êtes:
     </p>
     <ul>
       <li>une administration</li>
       <li>
-        une entreprise prestataire d&apos;une administration ou ayant une
-        délégation de service public
+        une entreprise prestataire d’une administration ou ayant une délégation
+        de service public
       </li>
       <li>
         un partenaire privé du service public de changement d'adresse en ligne :


### PR DESCRIPTION
- Replace `&apos;` by apostrophes "`’`"