### PR TITLE
Update technical contact description

### DIFF
--- a/src/pages/ApiParticulier.js
+++ b/src/pages/ApiParticulier.js
@@ -56,7 +56,6 @@ const contacts = {
     ),
     email: '',
     phone_number: '',
-    display_mobile_phone_label: true,
   },
 };
 

--- a/src/pages/ApiParticulier.js
+++ b/src/pages/ApiParticulier.js
@@ -49,9 +49,8 @@ const contacts = {
     heading: 'Responsable technique',
     description: () => (
       <p>
-        Cette personne recevra les accès techniques par mail. Le numéro de
-        téléphone doit être un numéro de téléphone mobile. Il sera utilisé pour
-        envoyer un code d'accès. Le responsable technique peut être le contact
+        Cette personne sera contactée en cas de problème technique sur votre
+        service. Le responsable technique peut être le contact
         technique de votre prestataire.
       </p>
     ),


### PR DESCRIPTION
Since the technical contact no longer receives an email from the API Particulier team, we don't need to explain it in the description anymore.