### PR TITLE
Patch 3

### DIFF
--- a/src/components/form-sections/aidants-connect-sections/StructureSection.js
+++ b/src/components/form-sections/aidants-connect-sections/StructureSection.js
@@ -159,6 +159,11 @@ export const StructureSection = () => {
         disabled={disabled}
         onChange={onChange}
       />
+   <Quote>
+        <p>
+          Attention :  1 structure = 1 lieu d'accueil. Merci de remplir une demande d'habilitation par lieu d'accueil.
+        </p>
+      </Quote>
       <TextInput
         label="Site web de votre structure"
         name="additional_content.organization_website"

--- a/src/pages/AidantsConnect.js
+++ b/src/pages/AidantsConnect.js
@@ -18,7 +18,7 @@ const contacts = {
     heading: 'Responsable de structure',
     description: (
       <p>
-        Le responsable est en charge de la mise en place et du suivi d'\Aidants Connect au sein du lieu d'\accueil. Il tient également à jour la liste des aidants habilités Aidants Connect sur son espace administrateur (à venir).
+        Le responsable est en charge de la mise en place et du suivi d'Aidants Connect au sein du lieu d'accueil. Il tient également à jour la liste des aidants habilités Aidants Connect sur son espace administrateur (à venir).
       </p>
     ),
     family_name: '',

--- a/src/pages/AidantsConnect.js
+++ b/src/pages/AidantsConnect.js
@@ -18,8 +18,7 @@ const contacts = {
     heading: 'Responsable de structure',
     description: (
       <p>
-        Le représentant légal ayant pouvoir de signature pour engager la
-        structure.
+        Le responsable est en charge de la mise en place et du suivi d'\Aidants Connect au sein du lieu d'\accueil. Il tient également à jour la liste des aidants habilités Aidants Connect sur son espace administrateur (à venir).
       </p>
     ),
     family_name: '',
@@ -96,7 +95,7 @@ const AidantsConnect = ({
         <StructureSection />
         <LabelsSection />
         <MiseEnOeuvreSection
-          sectionTitle="Coordonnées des référents de votre structure"
+          sectionTitle="Coordonnées du référent de votre structure"
           initialContacts={contacts}
           MiseEnOeuvreDescription={() => null}
         />


### PR DESCRIPTION
Mise à jour formulaire Aidants Connect : 

1. Ajouter un texte après "Description de votre structure" : " :danger: 1 structure = 1
lieu d'accueil. Merci de remplir une demande d'habilitation par lieu d'accueil."

2. Changer le titre avec : "Coordonnées du référent de la structure" et non « des
référents »

3.  Texte à changer en dessous du "Responsable de structure" :  "Le responsable est en charge de la mise en place et du suivi de l'outil Aidants Connect au sein du lieu d'accueil. Il tient également à jour la liste des aidants habilités Aidants Connect sur son espace administrateur (à venir)."