### PR TITLE
Mise à jour du texte sur les délibération

### DIFF
--- a/src/pages/ApiParticulier/index.js
+++ b/src/pages/ApiParticulier/index.js
@@ -24,9 +24,11 @@ const CadreJuridiqueDescription = () => (
       délibération du conseil municipal explicitant l’usage des données
       demandées.
     </p>
-   <p>
-      Important : à priori, vous n’avez pas de nouvelle délibération à réaliser. 
-Il vous suffit de déposer la dernière délibération tarifaire qui détaille les barèmes de facturation des services, ou le règlement qui décrit les données nécessaires à une instruction.
+    <p>
+      Important : à priori, vous n’avez pas de nouvelle délibération à réaliser.
+      Il vous suffit de déposer la dernière délibération tarifaire qui détaille
+      les barèmes de facturation des services, ou le règlement qui décrit les
+      données nécessaires à une instruction.
     </p>
   </>
 );

--- a/src/pages/ApiParticulier/index.js
+++ b/src/pages/ApiParticulier/index.js
@@ -24,27 +24,10 @@ const CadreJuridiqueDescription = () => (
       délibération du conseil municipal explicitant l’usage des données
       demandées.
     </p>
-    <p>
-      Voici quelques exemples de formulations que vous pouvez faire apparaitre
-      dans la délibération :
+   <p>
+      Important : à priori, vous n’avez pas de nouvelle délibération à réaliser. 
+Il vous suffit de déposer la dernière délibération tarifaire qui détaille les barèmes de facturation des services, ou le règlement qui décrit les données nécessaires à une instruction.
     </p>
-    <ul>
-      <li>
-        "Le quotient familial se base sur la valeur transmise par la CNAF."
-      </li>
-      <li>
-        "Le quotient familial est calculé par division du revenu fiscal de
-        référence par le nombre de parts du foyer."
-      </li>
-      <li>
-        "L’adresse fiscale est collectée afin de vérifier que le demandeur
-        réside bien sur la commune de XXX."
-      </li>
-      <li>
-        "La liste des enfants fournie par la CNAF est nécessaire à pré-remplir
-        l’inscription aux activités périscolaires."
-      </li>
-    </ul>
   </>
 );
 


### PR DESCRIPTION
La formulation précédente était trompeuse, car elle laissait entendre qu'il fallait réaliser une nouvelle délibération intégrant des phrases de ce type. Or l'information la plus importante est : 1/ pas nécessaire de refaire une délib 2/ prendre la dernière délib tarifaire